### PR TITLE
downgrade targetSdkVersion to 29

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 21
         compileSdkVersion = 30
-        targetSdkVersion = 30
+        targetSdkVersion = 29
         supportLibVersion = "28.0.0"
     }
     repositories {


### PR DESCRIPTION
I had to downgrade `targetSdkVersion` to runs aidi on android 11. More info: https://github.com/facebook/react-native/issues/30366