### PR TITLE
Mm 301 no desloguea aidi

### DIFF
--- a/src/src/presentation/dashboard/settings/SettingsScreen.tsx
+++ b/src/src/presentation/dashboard/settings/SettingsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from "react";
 import { SafeAreaView, StatusBar, StyleSheet, ScrollView } from "react-native";
-import RNRestart from "react-native-restart";
 
 import NavigationHeaderStyle from "../../common/NavigationHeaderStyle";
 import NavigationEnabledComponent from "../../util/NavigationEnabledComponent";
@@ -36,6 +35,7 @@ type SettingsScreenInternalProps = SettingsScreenProps & SettingsScreenStateProp
 
 export interface SettingsScreenNavigation {
 	// Access: StartAccessProps;
+	Login: {};
 	DashboardHome: DashboardScreenProps;
 	EditProfile: EditProfileProps;
 	IdentitySettings: IdentitySettingsProps;
@@ -78,13 +78,12 @@ class SettingsScreen extends NavigationEnabledComponent<SettingsScreenInternalPr
 	private logout() {
 		this.props.resetPendingLinking();
 		this.props.logout();
-		RNRestart.Restart();
+		this.navigate("Login", {});
 	}
 
 	navigateTo = (route: keyof SettingsScreenNavigation) => {
 		this.navigate(route, {});
 	};
-
 	render() {
 		return (
 			<Fragment>


### PR DESCRIPTION
* se redirecciono a la ventana de login
* se eliminó el conflicto que generaba  RNRestart.Restart() al recargar la app
* objetivo: cerrar sesión y redireccionar a la ventana logi

https://user-images.githubusercontent.com/55299077/143949024-c60937ad-8f34-46cd-98de-0cc68b094b1a.mp4


