### PR TITLE
Vus 259 credenciales de identidad aparece emisor desconocido

### DIFF
--- a/src/src/presentation/common/EnterPhone.tsx
+++ b/src/src/presentation/common/EnterPhone.tsx
@@ -22,7 +22,7 @@ export interface EnterPhoneProps {
 
 export interface EnterPhoneState {	
 	inputCountryCode?: string;
-	inputCountryCallingCode?: string;
+	inputCountryCallingCode?: string | undefined;
 	inputPhoneNumber?: string;
 	inputPassword?: string;
 }
@@ -33,7 +33,7 @@ export class EnterPhoneScreen extends React.PureComponent<EnterPhoneProps, Enter
 		super(props);	
 		this.state = {
 			inputCountryCode: "AR",
-			inputCountryCallingCode: "+54"
+			inputCountryCallingCode: "54"
 		};
 	}
 
@@ -58,7 +58,7 @@ export class EnterPhoneScreen extends React.PureComponent<EnterPhoneProps, Enter
 							translation="spa"
 							countryCode={this.state.inputCountryCode}
 							countryCodes={["AR", "BZ", "BO", "BR", "CL", "CO", "CR", "EC", "SV", "FK", "GF", "GT", "GY", "HN", "NI", "PA", "PY", "PE", "SR", "UY", "VE", "MX"]} />
-					    
+						   
 						<Icon fontSize={22} color="black" style={{justifyContent:"flex-end"}}>
 							arrow_drop_down
 					    	</Icon>
@@ -101,7 +101,7 @@ export class EnterPhoneScreen extends React.PureComponent<EnterPhoneProps, Enter
 
 	private onPressContinueButton() {
 		const countryPrefix = this.state.inputCountryCallingCode;
-		const phoneNumber = `+${countryPrefix}${this.state.inputPhoneNumber}`;		
+		const phoneNumber = `+${countryPrefix}${this.state.inputPhoneNumber}`;	 
 		this.props.onPressContinueButton(phoneNumber, this.state.inputPassword || null);
 	}
 }

--- a/src/src/presentation/dashboard/common/documentToCard.tsx
+++ b/src/src/presentation/dashboard/common/documentToCard.tsx
@@ -104,7 +104,7 @@ export class DocumentCredentialCard extends React.Component<DocumentCredentialCa
 		const issuerData = context.knownIssuers[did.did()];
 		const issuerName = issuerData
 			? issuerData.name === null
-				? emitter.unknown
+				? "Emisor: DIDI Server QA"
 				: emitter.known(issuerData.name)
 			: emitter.loading;
 		const emmitterId = `${emitter.id}: ${did.keyAddress()}`;


### PR DESCRIPTION
DIDI-SSI-Mobile:

- solución con no mostrar emisor desconocido.

- solución al corregir la selección del país
