### PR TITLE
fix: jcenter has been changed by mavenCentral

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         supportLibVersion = "28.0.0"
     }
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.1")
@@ -32,10 +32,13 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-
-        google()
-        jcenter()
-
+        mavenCentral {
+            // We don't want to fetch react-native from Maven Central as there are
+            // older versions over there.
+            content {
+                excludeGroup "com.facebook.react"
+            }
+        }
         maven { url "https://jitpack.io" } 
         maven { url "https://maven.google.com" } 
     }


### PR DESCRIPTION
DIDI-SSI-Mobile:

 * Se ha actualizado el build.gradlel con la propiedad  mavenCentral(), la que se está actualizando en este momento.